### PR TITLE
[WIP] countメソッドの代わりにsizeメソッドを使う

### DIFF
--- a/app/views/diaries/_diary.html.erb
+++ b/app/views/diaries/_diary.html.erb
@@ -8,7 +8,7 @@
             <%= link_to "変更する", new_diary_path(date: diary.date) %>
             <% end %>
           </span>
-          <span class="comments--count">コメント<%= diary.comments.count %>件</span>&nbsp;
+          <span class="comments--count">コメント<%= diary.comments.size %>件</span>&nbsp;
           <span class="comments--register">
             <% if signed_in? %>
             <%= link_to "コメントする", "#", class: "comments--display" %>


### PR DESCRIPTION
概要
---
erb内でcountメソッドを呼ぶと`select count(*) ~`が実行されるので、sizeメソッドを使うようにする